### PR TITLE
GROW-651 TITLE flows under sidebar if text is very long

### DIFF
--- a/src/css/grow/wiki/_wiki_content_main.scss
+++ b/src/css/grow/wiki/_wiki_content_main.scss
@@ -1,4 +1,7 @@
 #wiki-content-main {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
 	@import "../../primer/primer-markdown/index";
 
 	pre {


### PR DESCRIPTION
Hey @moltam89 ,

[GROW-651](https://issues.liferay.com/browse/GROW-651)

I fixed the issue by adding break-word to the wiki content wrapper, that includes the title as well.

Please review it.
Thanks,